### PR TITLE
add callback example to `select` component

### DIFF
--- a/src/components/select/mod.rs
+++ b/src/components/select/mod.rs
@@ -5,11 +5,14 @@ use yew::prelude::*;
 
 #[function_component(SelectExample)]
 pub fn select_example() -> Html {
+    let example6_state = use_state(|| "".to_string());
+
     let example1 = example! ("Select" => "select.1.example");
     let example2 = example! ("Select (with divider)" => "select.2.example");
     let example3 = example! ("Select (with groups)" => "select.3.example");
     let example4 = example! ("Select Checkbox (with groups)" => "select.4.example");
     let example5 = example! ("Select (multiple)" => "select.5.example");
+    let example6 = example! ("Select (multiple) with callback" => "select.6.example");
 
     html! {
         <>
@@ -19,6 +22,7 @@ pub fn select_example() -> Html {
                 {example3}
                 {example4}
                 {example5}
+                {example6}
             </ExamplePage>
         </>
     }

--- a/src/components/select/select.6.example
+++ b/src/components/select/select.6.example
@@ -1,0 +1,27 @@
+html!{
+    <>
+    <p>
+        <Select<String>
+            variant={SelectVariant::Multiple({
+                let example6_state = example6_state.clone();
+                Callback::from(move |value: Vec<String>| {
+                    example6_state.set(format!("{:?}", value));
+                })
+            })}
+            chip={ChipVariant::Values}
+        >
+            <SelectGroup<String> label="Group #1">
+                <SelectOption<String> value="A"/>
+                <SelectOption<String> value="B"/>
+                <SelectOption<String> value="C"/>
+            </SelectGroup<String>>
+            <SelectGroup<String> label="Group #2">
+                <SelectOption<String> value="D"/>
+                <SelectOption<String> value="E"/>
+                <SelectOption<String> value="F"/>
+            </SelectGroup<String>>
+        </Select<String>>
+    </p>
+    <p>{(*example6_state).clone()}</p>
+    </>
+}


### PR DESCRIPTION
This adds an example of a callback for the select component.

I think this example should make it more clear how it works.

fixes issue https://github.com/ctron/patternfly-yew/issues/37
